### PR TITLE
Add epub build option

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -164,6 +164,28 @@ texinfo_documents = [
 ]
 
 
+# -- Options for Epub output -------------------------------------------------
+
+# Bibliographic Dublin Core info.
+epub_title = project
+epub_author = author
+epub_publisher = author
+epub_copyright = copyright
+
+# The unique identifier of the text. This can be a ISBN number
+# or the project homepage.
+#
+# epub_identifier = ''
+
+# A unique identification for the text.
+#
+# epub_uid = ''
+
+# A list of files that should not be packed into the epub file.
+epub_exclude_files = ['search.html']
+
+
+
 # -- Extension configuration -------------------------------------------------
 
 # -- Options for intersphinx extension ---------------------------------------


### PR DESCRIPTION
This pull request provides the build option of the epub file, which is popular in the eBook readers.
In order to create `epub` file, at the top directory:
```
make epub
```
Thus, you can get `build/epub/SALMONsoftwaremanual.epub`.
